### PR TITLE
Add construct guidance MCP tool using artifact prompts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,11 @@ yarn-error.log*
 
 # env files (can opt-in for committing if needed)
 .env*
+!mcp-server/.env
+
+# MCP server build artifacts and dependencies
+/mcp-server/build/
+/mcp-server/node_modules/
 
 # vercel
 .vercel

--- a/mcp-server/.env
+++ b/mcp-server/.env
@@ -1,0 +1,14 @@
+# Directory where Claude-supplied artifacts (prompts, context files, etc.) are stored
+CLAUDE_AI_ARTIFACTS_PATH=./artifacts
+
+# Base URL for the LLM runtime that constructs guidance
+LLM_API_URL=http://localhost:11434/v1/generate
+
+# API key or token for authenticating with the runtime (leave blank if not required)
+LLM_API_KEY=
+
+# Default model and tuning settings for construct guidance operations
+LLM_MODEL=claude-3-opus
+LLM_TEMPERATURE=0.2
+LLM_MAX_TOKENS=1024
+LLM_REQUEST_TIMEOUT_MS=60000

--- a/mcp-server/src/index.ts
+++ b/mcp-server/src/index.ts
@@ -3,7 +3,7 @@
 /**
  * MCP Server for PDF Takeoff Tool
  * Provides tools for construction measurement and PDF analysis
- * 
+ *
  * This is a minimal scaffold implementing MCP (Model Context Protocol)
  * with a placeholder echo tool for development and testing.
  */
@@ -15,6 +15,52 @@ import {
   ListToolsRequestSchema,
   Tool,
 } from '@modelcontextprotocol/sdk/types.js';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { constructGuidance, type ConstructGuidanceArgs } from './tools/constructGuidance.js';
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+function loadEnvFile(envPath: string) {
+  if (!fs.existsSync(envPath)) {
+    return;
+  }
+
+  const contents = fs.readFileSync(envPath, 'utf8');
+  const lines = contents.split(/\r?\n/);
+
+  for (const line of lines) {
+    if (!line || line.trim().length === 0 || line.trim().startsWith('#')) {
+      continue;
+    }
+
+    const equalsIndex = line.indexOf('=');
+    if (equalsIndex === -1) {
+      continue;
+    }
+
+    const key = line.slice(0, equalsIndex).trim();
+    if (!key) {
+      continue;
+    }
+
+    let value = line.slice(equalsIndex + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+
+    if (!(key in process.env)) {
+      process.env[key] = value;
+    }
+  }
+}
+
+loadEnvFile(path.resolve(__dirname, '../.env'));
 
 interface EchoArgs {
   message?: string;
@@ -54,6 +100,50 @@ const TOOLS: Tool[] = [
       required: ['message'],
     },
   },
+  {
+    name: 'construct_guidance',
+    description:
+      'Generate constructability guidance using artifacts and an external LLM runtime',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        promptFile: {
+          type: 'string',
+          description:
+            'Relative path (from CLAUDE_AI_ARTIFACTS_PATH) to the primary prompt file',
+        },
+        contextFiles: {
+          type: 'array',
+          items: {
+            type: 'string',
+          },
+          description:
+            'Additional artifact files to include as supporting context (relative paths)',
+        },
+        model: {
+          type: 'string',
+          description: 'Optional override for the model identifier',
+        },
+        variables: {
+          type: 'object',
+          additionalProperties: {
+            type: 'string',
+          },
+          description:
+            'Key/value substitutions that will be interpolated into the prompt template',
+        },
+        temperature: {
+          type: 'number',
+          description: 'Optional override for the sampling temperature',
+        },
+        maxTokens: {
+          type: 'number',
+          description: 'Optional override for the maximum tokens returned by the model',
+        },
+      },
+      required: ['promptFile'],
+    },
+  },
   // TODO: Add more construction-specific tools:
   // - pdf_extract_measurements
   // - calculate_area
@@ -74,7 +164,7 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
   try {
     switch (name) {
       case 'echo': {
-        const { message } = args as EchoArgs;
+        const { message } = (args ?? {}) as EchoArgs;
         return {
           content: [
             {
@@ -82,6 +172,36 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               text: `Echo: ${message || 'No message provided'}`,
             },
           ],
+        };
+      }
+
+      case 'construct_guidance': {
+        const rawArgs = (args ?? {}) as unknown;
+        if (!rawArgs || typeof rawArgs !== 'object') {
+          throw new Error('construct_guidance requires an object of arguments.');
+        }
+
+        const { promptFile } = rawArgs as { promptFile?: unknown };
+        if (typeof promptFile !== 'string' || promptFile.trim().length === 0) {
+          throw new Error('construct_guidance requires a string promptFile argument.');
+        }
+
+        const guidanceArgs = rawArgs as ConstructGuidanceArgs;
+        const result = await constructGuidance(guidanceArgs);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: result.text,
+            },
+          ],
+          ...(result.metadata
+            ? {
+                meta: {
+                  construct_guidance: result.metadata,
+                },
+              }
+            : {}),
         };
       }
 

--- a/mcp-server/src/tools/constructGuidance.ts
+++ b/mcp-server/src/tools/constructGuidance.ts
@@ -1,0 +1,209 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import http from 'node:http';
+import https from 'node:https';
+
+export interface ConstructGuidanceArgs {
+  promptFile: string;
+  contextFiles?: string[];
+  model?: string;
+  variables?: Record<string, string>;
+  temperature?: number;
+  maxTokens?: number;
+}
+
+export interface ConstructGuidanceResult {
+  text: string;
+  metadata?: Record<string, unknown>;
+}
+
+const DEFAULT_TIMEOUT = Number.parseInt(process.env.LLM_REQUEST_TIMEOUT_MS ?? '60000', 10);
+
+function resolveArtifactsPath(): string {
+  const basePath = process.env.CLAUDE_AI_ARTIFACTS_PATH;
+  if (!basePath) {
+    throw new Error(
+      'CLAUDE_AI_ARTIFACTS_PATH is not set. Please configure it in mcp-server/.env so the MCP server can read prompt artifacts.'
+    );
+  }
+
+  return path.resolve(basePath);
+}
+
+async function readArtifact(artifactPath: string, description: string): Promise<string> {
+  try {
+    return await fs.readFile(artifactPath, 'utf8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+      throw new Error(
+        `${description} not found at ${artifactPath}. Ensure the file exists in CLAUDE_AI_ARTIFACTS_PATH.`
+      );
+    }
+
+    throw new Error(`Unable to read ${description} at ${artifactPath}: ${(error as Error).message}`);
+  }
+}
+
+function applyVariables(template: string, variables?: Record<string, string>): string {
+  if (!variables) {
+    return template;
+  }
+
+  return template.replace(/{{\s*(\w+)\s*}}/g, (_, key: string) => {
+    if (!(key in variables)) {
+      throw new Error(`Missing variable "${key}" required by the prompt template.`);
+    }
+    return variables[key];
+  });
+}
+
+async function callLlm(payload: Record<string, unknown>): Promise<unknown> {
+  const urlString = process.env.LLM_API_URL;
+  if (!urlString) {
+    throw new Error('LLM_API_URL is not set. Configure it in mcp-server/.env to point to your LLM runtime.');
+  }
+
+  const timeout = Number.isFinite(DEFAULT_TIMEOUT) ? DEFAULT_TIMEOUT : 60000;
+  const requestBody = JSON.stringify(payload);
+  const url = new URL(urlString);
+  const isHttps = url.protocol === 'https:';
+  const client = isHttps ? https : http;
+
+  const headers: http.OutgoingHttpHeaders = {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(requestBody),
+  };
+
+  if (process.env.LLM_API_KEY) {
+    headers.Authorization = `Bearer ${process.env.LLM_API_KEY}`;
+  }
+
+  const rawResponse = await new Promise<string>((resolve, reject) => {
+    const request = client.request(
+      {
+        hostname: url.hostname,
+        port: url.port || (isHttps ? 443 : 80),
+        path: `${url.pathname}${url.search}`,
+        method: 'POST',
+        headers,
+      },
+      (res) => {
+        const statusCode = res.statusCode ?? 0;
+        let responseData = '';
+
+        res.setEncoding('utf8');
+        res.on('data', (chunk) => {
+          responseData += chunk;
+        });
+        res.on('end', () => {
+          if (statusCode < 200 || statusCode >= 300) {
+            reject(
+              new Error(
+                `LLM runtime responded with status ${statusCode}: ${responseData || res.statusMessage || 'Unknown error'}`
+              )
+            );
+            return;
+          }
+          resolve(responseData);
+        });
+      }
+    );
+
+    let didTimeout = false;
+
+    request.on('error', (error) => {
+      if (didTimeout) {
+        reject(
+          new Error(
+            `Timed out after ${timeout}ms waiting for the LLM runtime. Increase LLM_REQUEST_TIMEOUT_MS if needed.`
+          )
+        );
+      } else {
+        reject(new Error(`Failed to call LLM runtime: ${error.message}`));
+      }
+    });
+
+    request.setTimeout(timeout, () => {
+      didTimeout = true;
+      request.destroy(new Error('Request timed out'));
+    });
+
+    request.write(requestBody);
+    request.end();
+  });
+
+  try {
+    return JSON.parse(rawResponse);
+  } catch (error) {
+    return rawResponse;
+  }
+}
+
+function extractTextFromResponse(data: unknown): string {
+  if (typeof data === 'string') {
+    return data;
+  }
+
+  if (data && typeof data === 'object') {
+    const candidate =
+      (data as Record<string, unknown>).output ??
+      (data as Record<string, unknown>).text ??
+      (data as Record<string, unknown>).completion ??
+      (data as Record<string, unknown>).message;
+
+    if (typeof candidate === 'string') {
+      return candidate;
+    }
+
+    if (Array.isArray(candidate)) {
+      return candidate.map((item) => (typeof item === 'string' ? item : JSON.stringify(item))).join('\n');
+    }
+  }
+
+  return JSON.stringify(data, null, 2);
+}
+
+export async function constructGuidance(args: ConstructGuidanceArgs): Promise<ConstructGuidanceResult> {
+  if (!args?.promptFile) {
+    throw new Error('promptFile is required when calling construct_guidance.');
+  }
+
+  const artifactsPath = resolveArtifactsPath();
+  const promptPath = path.resolve(artifactsPath, args.promptFile);
+  const promptTemplate = await readArtifact(promptPath, 'Prompt template');
+  const prompt = applyVariables(promptTemplate, args.variables);
+
+  let context: string[] = [];
+  if (args.contextFiles?.length) {
+    context = await Promise.all(
+      args.contextFiles.map(async (contextFile) => {
+        const contextPath = path.resolve(artifactsPath, contextFile);
+        return readArtifact(contextPath, `Context file ${contextFile}`);
+      })
+    );
+  }
+
+  const payload: Record<string, unknown> = {
+    model: args.model ?? process.env.LLM_MODEL,
+    prompt,
+    temperature: args.temperature ?? Number.parseFloat(process.env.LLM_TEMPERATURE ?? '0'),
+    max_tokens: args.maxTokens ?? Number.parseInt(process.env.LLM_MAX_TOKENS ?? '1024', 10),
+  };
+
+  if (context.length) {
+    payload.context = context;
+  }
+
+  const response = await callLlm(payload);
+  const text = extractTextFromResponse(response);
+
+  return {
+    text,
+    metadata: {
+      model: payload.model,
+      promptFile: promptPath,
+      contextFiles: args.contextFiles?.map((file) => path.resolve(artifactsPath, file)) ?? [],
+      runtimeUrl: process.env.LLM_API_URL,
+    },
+  };
+}


### PR DESCRIPTION
## Summary
- load MCP server environment variables from mcp-server/.env without extra dependencies
- add a construct_guidance helper that reads artifact prompts, calls the configured LLM runtime, and surfaces clear errors
- register the construct_guidance tool, extend request handling, and document setup and usage including Windows artifact paths

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68efbf9b79c48331a0600ed3c4272911