### PR TITLE
Ensure measurement preview uses linear drawing path for measure tool

### DIFF
--- a/src/hooks/usePdfHandler.ts
+++ b/src/hooks/usePdfHandler.ts
@@ -160,7 +160,9 @@ export const usePdfHandler = () => {
 
     // Draw current measurement preview
     if (currentMeasurement.length > 0) {
-      drawMeasurement(currentMeasurement, true, tool as 'area' | 'linear');
+      const previewType: 'area' | 'linear' =
+        tool === 'measure' ? 'linear' : 'area';
+      drawMeasurement(currentMeasurement, true, previewType);
     }
   }, [
     measurements,


### PR DESCRIPTION
## Summary
- map the measure tool preview to the linear measurement type so preview drawing uses the saved linear path
- keep preview labels on linear measurements using the distance calculation and red styling

## Testing
- npm run lint

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_691ec55c70d48331a9f0f5f088ffc361)